### PR TITLE
Switched Khan radio frequency to default SS13 Security frequency. (TEMPORARY)

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -204,9 +204,9 @@
 
 /obj/item/encryptionkey/headset_khans
 	name = "Khan radio encryption key"
-	desc = "An encryption key for a radio headset.  To access the Khan channel, use :a."
+	desc = "An encryption key for a radio headset.  To access the Khan channel, use :h."
 	icon_state = "cypherkey"
-	channels = list(RADIO_CHANNEL_KHANS = 1)
+	channels = list(RADIO_CHANNEL_SECURITY = 1)
 
 /obj/item/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
 	channels = list(RADIO_CHANNEL_COMMAND = 1, RADIO_CHANNEL_SECURITY = 1, RADIO_CHANNEL_ENGINEERING = 1, RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_MEDICAL = 1, RADIO_CHANNEL_SUPPLY = 1, RADIO_CHANNEL_SERVICE = 1, RADIO_CHANNEL_AI_PRIVATE = 1)


### PR DESCRIPTION
Temporary hotfix to give Khans a functional private radio channel until the issue with their original frequency can be resolved.

Note, 'Town' radio frequency has the same issue of not working.