### PR TITLE
Adjusted decay rate

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -181,7 +181,7 @@
 ////organ defines
 #define STANDARD_ORGAN_THRESHOLD 	100
 #define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / (2 SECONDS)))
-#define STANDARD_ORGAN_DECAY		(1/(30 MINUTES / (2 SECONDS)))		//designed to fail organs when left to decay for ~15 minutes. 2 SECOND is SSmobs tickrate.
+#define STANDARD_ORGAN_DECAY		(1/(60 MINUTES / (2 SECONDS)))		//designed to fail organs when left to decay for ~15 minutes. 2 SECOND is SSmobs tickrate.
 
 
 //used for the can_chromosome var on mutations


### PR DESCRIPTION
Doubled the time required for a body to decay to make it less difficult for followers after a body takes too long to be found and ends up going necrotic.
Most likely will be rebalanced once we reach higher pop numbers and it's more common for people to stumble upon bodies.